### PR TITLE
Add docker-publish action to build and publish docker image

### DIFF
--- a/.github/workflows /docker-publish.yml
+++ b/.github/workflows /docker-publish.yml
@@ -1,0 +1,62 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - snapshot
+    # A tag will build and publish the Docker images
+    tags: [ '*.*.*' ]
+  pull_request:
+    branches: [ "snapshot" ]
+
+jobs:
+  build-and-push:
+    strategy:
+      matrix:
+        dist: [corretto, debian, zulu, zulu-alpine, adoptopenjdk, msopenjdk]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get Tags
+        id: get-tags
+        uses: actions/github-script@v6
+        with:
+          script: |
+            function buildFullTag(tag) {
+              return "adaptris/interlok:" + tag + "-${{ matrix.dist }}";
+            }
+            var tags = buildFullTag("snapshot");
+            if ('${{ github.ref_type }}' == 'tag') {
+              tags = buildFullTag("${{ github.ref_name }}") + "," + buildFullTag("latest");
+            }
+            return tags
+          result-encoding: string
+
+      - name: Echo
+        run: |
+          echo "Build Docker image: ${{ steps.get-tags.outputs.result }}, Publish: ${{ github.event_name != 'pull_request' }}"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./${{ matrix.dist }}/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.get-tags.outputs.result }}
+          labels: interlok
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Motivation

To automate docker publish action

## Modification

Added a github action to build and publish docker images

## PR Checklist

- [x] been self-reviewed.

## Result

Docker snapshot and release images will be built and published automatically

## Testing

When pushing to snapshot new snapshot versions will be published.
When creating a pull request the action will build the image to see if it's working
When tagging the repo new release versions will be published
